### PR TITLE
upgrade maven-compiler-plugin version to 3.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>1.17</source>
                     <target>1.17</target>


### PR DESCRIPTION
the version fixes issue with generation MapStruct classes for test scope